### PR TITLE
Fix #3: handle null props

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,13 +124,13 @@ exports.infect = function(klass, options) {
   }
 };
 
-function updateStash(newStash, oldStash, key, modelOrCollection, type, properties) {
+function updateStash(newStash, oldStash, key, modelOrCollection, _type, properties) {
   var changed = false, i, property;
   if (!oldStash[key]) {
     changed = (modelOrCollection != null);
   } else if (oldStash[key] && !modelOrCollection) {
     changed = true;
-  } else if (oldStash[key].type !== type) {
+  } else if (oldStash[key]._type !== _type) {
     changed = true;
   } else {
     for (i in properties) {
@@ -140,7 +140,7 @@ function updateStash(newStash, oldStash, key, modelOrCollection, type, propertie
   }
   if (changed) {
     if (modelOrCollection) {
-      newStash[key] = {type: type};
+      newStash[key] = {_type: _type};
       for (i in properties) {
         property = properties[i];
         newStash[key][property] = modelOrCollection[property];
@@ -192,8 +192,8 @@ exports.PureRenderMixin = {
       modelOrCollection = newObjects[key];
       var isImmutableModel = modelOrCollection && modelOrCollection._immutableBackboneModel;
       var isImmutableCollection = modelOrCollection && modelOrCollection._immutableBackboneCollection;
-      var wasImmutableModel = oldStash[key] && oldStash[key].type === 'model';
-      var wasImmutableCollection = oldStash[key] && oldStash[key].type === 'collection';
+      var wasImmutableModel = oldStash[key] && oldStash[key]._type === 'model';
+      var wasImmutableCollection = oldStash[key] && oldStash[key]._type === 'collection';
       if (isImmutableModel || wasImmutableModel) {
         changed = updateStash(newStash, oldStash, key, modelOrCollection, 'model', ['attributes']) || changed;
       } else if (isImmutableCollection || wasImmutableCollection) {

--- a/index.js
+++ b/index.js
@@ -194,7 +194,7 @@ exports.PureRenderMixin = {
       var isImmutableCollection = modelOrCollection && modelOrCollection._immutableBackboneCollection;
       var wasImmutableModel = oldStash[key] && oldStash[key]._type === 'model';
       var wasImmutableCollection = oldStash[key] && oldStash[key]._type === 'collection';
-      if (isImmutableModel || wasImmutableModel) {
+      if (isImmutableModel || (!isImmutableCollection && wasImmutableModel)) {
         changed = updateStash(newStash, oldStash, key, modelOrCollection, 'model', ['attributes']) || changed;
       } else if (isImmutableCollection || wasImmutableCollection) {
         changed = updateStash(newStash, oldStash, key, modelOrCollection, 'collection', ['models']) || changed;


### PR DESCRIPTION
The PureRenderMixin was not correctly dealing with null props (in fact, it was trying to access `_immutableBackboneModel` of `undefined` which is clearly very bad). This PR resolves this, handling both a prop going from null to not null and back again.